### PR TITLE
Bump to 9.4.2

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -9,7 +9,7 @@ on:
         type: string
       vtk_full_version:
         description: "VTK full version"
-        default: "9.4.1"
+        default: "9.4.2"
         type: string
       vtk_short_version:
         description: "VTK short version"
@@ -17,7 +17,7 @@ on:
         type: string
       tag_name:
         description: "Tag name"
-        default: "v9.4.1-py3.12"
+        default: "v9.4.2-py3.12"
         type: string
 
 


### PR DESCRIPTION
Pyvista is incompatible with 9.4.1 - can we bump to 9.4.2?

See discussion at https://github.com/FEniCS/dolfinx/pull/3737